### PR TITLE
feat: Add a user interface to chrome extension

### DIFF
--- a/chrome_extension/debucsser.js
+++ b/chrome_extension/debucsser.js
@@ -111,12 +111,12 @@ class Debucsser {
     style.innerHTML = `
     <style>
       .debucsser-label {
-        position: fixed; 
+        position: fixed;
         font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-        padding: 10px 20px; 
-        background: #333; 
+        padding: 10px 20px;
+        background: #333;
         border-radius: 3px;
-        color: #f9f9f9; 
+        color: #f9f9f9;
         opacity: 0.9;
         z-index: 999;
       }
@@ -128,6 +128,5 @@ class Debucsser {
   }
 }
 
-
-// init debucsser without custom config 
-const debug = new Debucsser().init();
+// init debucsser without custom config
+let debug = new Debucsser().init();

--- a/chrome_extension/manifest.json
+++ b/chrome_extension/manifest.json
@@ -5,7 +5,8 @@
   "description": "CSS debugging made easy",
   "homepage_url": "https://github.com/lucagez/Debucsser",
   "browser_action": {
-    "default_title": "Debucsser"
+    "default_title": "Debucsser",
+    "default_popup": "popup.html"
   },
   "background": {
     "scripts": [
@@ -16,6 +17,7 @@
   "permissions": [
     "https://*/*",
     "http://*/*",
-    "tabs"
+    "tabs",
+    "storage"
   ]
 }

--- a/chrome_extension/popup.html
+++ b/chrome_extension/popup.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <style>
+    /* The switch - the box around the slider */
+    .switch {
+      position: relative;
+      display: inline-block;
+      width: 60px;
+      height: 34px;
+    }
+
+    /* Hide default HTML checkbox */
+    .switch input {
+      opacity: 0;
+      width: 0;
+      height: 0;
+    }
+
+    /* The slider */
+    .slider {
+      position: absolute;
+      cursor: pointer;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background-color: #ccc;
+      -webkit-transition: .4s;
+      transition: .4s;
+    }
+
+    .slider:before {
+      position: absolute;
+      content: "";
+      height: 26px;
+      width: 26px;
+      left: 4px;
+      bottom: 4px;
+      background-color: white;
+      -webkit-transition: .4s;
+      transition: .4s;
+    }
+
+    input:checked + .slider {
+      background-color: #2196F3;
+    }
+
+    input:focus + .slider {
+      box-shadow: 0 0 1px #2196F3;
+    }
+
+    input:checked + .slider:before {
+      -webkit-transform: translateX(26px);
+      -ms-transform: translateX(26px);
+      transform: translateX(26px);
+    }
+
+    /* Rounded sliders */
+    .slider.round {
+      border-radius: 34px;
+    }
+
+    .slider.round:before {
+      border-radius: 50%;
+    }
+  </style>
+</head>
+
+<body>
+  <h1>DebuCSSer</h1>
+  <label class="switch">
+    <input type="checkbox" name="active">
+    <span class="slider round"></span>
+  </label> Activate
+  <br />
+  <form id="debucsser-settings">
+    <label>Outline Color</label>
+    <input type="color" name="outlineColor" class="debucsser-form-field" />
+    <label>Outline Width</label>
+    <input type="number" name="outlineWidth" class="debucsser-form-field" />
+    <label>Outline style</label>
+    <select name="outlineStyle" class="debucsser-form-field">
+      <option selected>solid</option>
+      <option>dashed</option>
+      <option>dotted</option>
+      <option>groove</option>
+      <option>double</option>
+      <option>ridge</option>
+      <option>inset</option>
+      <option>outset</option>
+    </select>
+    <label>Custom Class</label>
+    <input type="text" name="customClass" class="debucsser-form-field" />
+    <label>Main key</label>
+    <input type="number" name="mainKey" class="debucsser-form-field" />
+    <label>Second key</label>
+    <input type="number" name="secondKey" class="debucsser-form-field" />
+    <label>Grayscale On Debug</label>
+    <input type="checkbox" name="grayscaleOnDebug" class="debucsser-form-field" value="true">
+    <label>Grayscale On Debug All</label>
+    <input type="checkbox" name="grayscaleOnDebugAll" class="debucsser-form-field" value="true">
+  </form>
+  <script src="popup.js"></script>
+</body>
+
+</html>

--- a/chrome_extension/popup.js
+++ b/chrome_extension/popup.js
@@ -1,0 +1,35 @@
+/* ToDo
+* On start check if there are options already set
+* Save options on change
+* Change debucsser behavior on change
+*/
+
+function saveSettings (event) {
+  const field = event.target;
+  const key = field.name;
+  const value = field.value;
+
+  // Create a key value pair for each form field based on the html name and value of the field.
+  chrome.storage.sync.set({ [key]: value}, () => {
+    console.log('Value ist set to', value);
+  })
+}
+
+function applySettings (field) {
+  chrome.storage.sync.get([field.name], (result) => {
+    field.value = result[field.name];
+  });
+}
+
+function init() {
+  const formFields = document.querySelectorAll('.debucsser-form-field');
+
+  formFields.forEach(field => {
+    // set initial values for each form field
+    applySettings(field);
+    // register event listeners for each form field
+    field.addEventListener('change', event => saveSettings(event));
+  });
+}
+
+init();


### PR DESCRIPTION
Work in Progress

This PR adds a basic UI to the chrome extension.

* A form where a user can change their settings (synced cross devices via chrome storage API)
* A toggle switch to turn DebuCSSer on/off

To use the storage API we need a new permission (see manifest.json).

ToDo:

- [ ] Styles
- [ ] Add support for the checkboxes
- [ ] Set defaults in the form if the user did not set own settings
- [ ] Make use of the settings in the background.js script
- [ ] Make the toggle switch work 