### PR TITLE
Improvised the default styling of the label 

### DIFF
--- a/app/src/debucsser.js
+++ b/app/src/debucsser.js
@@ -1,7 +1,8 @@
 class Debucsser {
   constructor(props) {
     this.config = props || {};
-    this.color = this.config.color || 'palevioletred';
+    //just changed the color from palecioletred to bluish color 
+    this.color = this.config.color || 'rgba(121,134,203 ,1)';
     this.width = this.config.width || '3px';
     this.style = this.config.style || 'solid';
     this.customClass = this.config.customClass || null;
@@ -66,7 +67,7 @@ class Debucsser {
     const style = document.createElement('style');
     style.innerHTML = `
       .debucsser {
-        outline: ${this.string};
+        outline: ${this.string};        
         ${this.config.grayscaleOnDebug && 'filter: grayscale(100%);'}
       }
     `;
@@ -89,13 +90,33 @@ class Debucsser {
   }
   labels(e) {
     if (e.target) {
-      const classList = e.target.classList ? e.target.classList.value.replace('debucsser', '') : undefined;
+      //If there are more than 2 classes for an element, spaces are replaced with '.' to achieve a format like h1.bar__one.bar__two 
+      const classList = e.target.classList ? e.target.classList.value.replace(' debucsser', '').replace('debucsser','') : undefined;
+      var improvisedClassList = undefined;
+      if(classList !== '')
+      {
+       improvisedClassList = '.'+classList.split(' ').join('.');
+      }
+      const tagName = e.target.tagName;
+      //computedStyle gets computed style properties for a selected element
+      const computedStyle = window.getComputedStyle(e.target,null);
+      //we get the color,font,background-color,display type and add them to debucsser-label to display them
+      const computedColor = computedStyle.getPropertyValue('color');
+      const fontName=computedStyle['font-size']+' '+computedStyle['font-family'];
+      const computedBackgroundColor = computedStyle['background-color'];
+      const displayType = computedStyle.getPropertyValue('display');
       const id = e.target.id ? '#' + e.target.id : undefined;
       const dimensions = e.target.getBoundingClientRect();
+      //an extra container (debucsser-label__container) has been created to acheieve 'flex'ible layout for debucsser__label
       this.label.innerHTML = `
-        <h2>class: <strong>${classList || `¯\\_(ツ)_/¯`}</strong></h2>
-        <h2>id: <strong>${id || `¯\\_(ツ)_/¯`}</strong></h2>
-        <h2><strong>${dimensions.width.toFixed(0)}px</strong> × <strong>${dimensions.height.toFixed(0)}px</strong></h2>
+      <div class="debucsser-label__container">
+        <p id="debucsser__tagname">${tagName.toLowerCase()}<strong>${improvisedClassList || id || '' }</strong></p>
+        <p>display: <strong>${displayType || `¯\\_(ツ)_/¯`}</strong></p>
+        <p>size: <strong>${dimensions.width.toFixed(0)}px</strong> × <strong>${dimensions.height.toFixed(0)}px</strong></p>
+        <p>Background: <strong>${computedBackgroundColor}</strong></p>
+        <p>color: <strong>${computedColor}</strong></p>
+        <p>font: <strong>${fontName}</strong></p>
+        </div>
       `;
       this.label.style = `display: block; top:${e.clientY + 20}px; left:${e.clientX + 20}px;`;
     } else {
@@ -103,21 +124,67 @@ class Debucsser {
     }
   }
   inject_label_style() {
+    //the whole styling is to improvise the look and feel of the label
     const style = document.createElement('style');
     style.innerHTML = `
       .debucsser-label {
         position: fixed;
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-        padding: 10px 20px;
-        background: #333;
-        border-radius: 3px;
-        color: #f9f9f9;
-        opacity: 0.9;
         z-index: 999;
+       outline:none;
       }
-      .debucsser-label strong {
+      .debucsser-label__container
+      {
+        display: flex;
+        flex-flow:column nowrap;
+        max-width:300px;
+        justify-content: center;
+        color: #f0f0f0;
+        background:#333;
+        border-radius:4px;
+        -webkit-border-radius:4px;
+        -moz-border-radius:4px;
+        -ms-border-radius:4px;
+        -o-border-radius:4px;
+        box-shadow:0px 10px 30px rgba(0,0,0,0.5);
+        opacity:0.95;
+        outline:none;
+      }
+    .debucsser-label__container::after
+    {
+      content: "";
+      position: absolute;
+      top: 0%;
+      left: 0%;
+      margin-left: -5px;
+      border-width: 5px;
+      border-style: solid;
+      border-color: #333 transparent transparent transparent;
+    }
+    .debucsser-label__container p{
+        flex: 1 1 auto ;
+        margin:0;
+        padding:10px 5px 10px 15px;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        outline:none;
+    }
+    .debucsser-label__container p strong{
+        text-align: right;
         color: palevioletred;
-      }
+        outline:none;
+    }
+    #debucsser__tagname
+    {
+      text-align:center;
+      padding:5px 2px 2px 2px;
+      color:rgba(255,183,77 ,1);
+
+      border-bottom:1px solid #f0f0f0;
+    }
+    #debucsser__tagname strong
+    {
+      padding:0px 2px 2px 2px;
+      color:rgba(52,152,219 ,1);
+    }
     `;
     document.body.appendChild(style);
   }

--- a/module/debucsser.js
+++ b/module/debucsser.js
@@ -1,7 +1,8 @@
 export default class Debucsser {
   constructor(props) {
     this.config = props || {};
-    this.color = this.config.color || 'palevioletred';
+    //changed the color from palecioletred to bluish color since blue color is used to inspect the element 
+    this.color = this.config.color || 'rgba(121,134,203 ,1)';
     this.width = this.config.width || '3px';
     this.style = this.config.style || 'solid';
     this.customClass = this.config.customClass || null;
@@ -66,7 +67,7 @@ export default class Debucsser {
     const style = document.createElement('style');
     style.innerHTML = `
       .debucsser {
-        outline: ${this.string};
+        outline: ${this.string};        
         ${this.config.grayscaleOnDebug && 'filter: grayscale(100%);'}
       }
     `;
@@ -89,13 +90,33 @@ export default class Debucsser {
   }
   labels(e) {
     if (e.target) {
-      const classList = e.target.classList ? e.target.classList.value.replace('debucsser', '') : undefined;
+      //If there are more than 2 classes for an element, spaces are replaced with '.' to achieve a format like h1.bar__one.bar__two 
+      const classList = e.target.classList ? e.target.classList.value.replace(' debucsser', '').replace('debucsser','') : undefined;
+      var improvisedClassList = undefined;
+      if(classList !== '')
+      {
+       improvisedClassList = '.'+classList.split(' ').join('.');
+      }
+      const tagName = e.target.tagName;
+      //computedStyle gets computed style properties for a selected element
+      const computedStyle = window.getComputedStyle(e.target,null);
+      //we get the color,font,background-color,display type and add them to debucsser-label to display them
+      const computedColor = computedStyle.getPropertyValue('color');
+      const fontName=computedStyle['font-size']+' '+computedStyle['font-family'];
+      const computedBackgroundColor = computedStyle['background-color'];
+      const displayType = computedStyle.getPropertyValue('display');
       const id = e.target.id ? '#' + e.target.id : undefined;
       const dimensions = e.target.getBoundingClientRect();
+      //an extra container (debucsser-label__container) has been created to acheieve 'flex'ible layout for debucsser__label
       this.label.innerHTML = `
-        <h2>class: <strong>${classList || `¯\\_(ツ)_/¯`}</strong></h2>
-        <h2>id: <strong>${id || `¯\\_(ツ)_/¯`}</strong></h2>
-        <h2><strong>${dimensions.width.toFixed(0)}px</strong> × <strong>${dimensions.height.toFixed(0)}px</strong></h2>
+      <div class="debucsser-label__container">
+        <p id="debucsser__tagname">${tagName.toLowerCase()}<strong>${improvisedClassList || id || '' }</strong></p>
+        <p>display: <strong>${displayType || `¯\\_(ツ)_/¯`}</strong></p>
+        <p>size: <strong>${dimensions.width.toFixed(0)}px</strong> × <strong>${dimensions.height.toFixed(0)}px</strong></p>
+        <p>background: <strong>${computedBackgroundColor}</strong></p>
+        <p>color: <strong>${computedColor}</strong></p>
+        <p>font: <strong>${fontName}</strong></p>
+        </div>
       `;
       this.label.style = `display: block; top:${e.clientY + 20}px; left:${e.clientX + 20}px;`;
     } else {
@@ -103,22 +124,76 @@ export default class Debucsser {
     }
   }
   inject_label_style() {
+    //the whole styling is to improvise the look and feel of the label
     const style = document.createElement('style');
     style.innerHTML = `
       .debucsser-label {
         position: fixed;
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-        padding: 10px 20px;
-        background: #333;
-        border-radius: 3px;
-        color: #f9f9f9;
-        opacity: 0.9;
         z-index: 999;
+       outline:none;
       }
-      .debucsser-label strong {
+      .debucsser-label__container
+      {
+        display: flex;
+        flex-flow:column nowrap;
+        max-width:300px;
+        justify-content: center;
+        color: #f0f0f0;
+        background:#333;
+        border-radius:4px;
+        -webkit-border-radius:4px;
+        -moz-border-radius:4px;
+        -ms-border-radius:4px;
+        -o-border-radius:4px;
+        box-shadow:0px 10px 30px rgba(0,0,0,0.5);
+        opacity:0.95;
+        outline:none;
+      }
+    .debucsser-label__container::after
+    {
+      content: "";
+      position: absolute;
+      top: 0%;
+      left: 0%;
+      margin-left: -5px;
+      border-width: 5px;
+      border-style: solid;
+      border-color: #333 transparent transparent transparent;
+    }
+    .debucsser-label__container p{
+        flex: 1 1 auto ;
+        margin:0;
+        padding:10px 5px 10px 15px;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        outline:none;
+    }
+    .debucsser-label__container p strong{
+        text-align: right;
         color: palevioletred;
-      }
+        outline:none;
+    }
+    #debucsser__tagname
+    {
+      text-align:center;
+      padding:5px 2px 2px 2px;
+      color:rgba(255,183,77 ,1);
+
+      border-bottom:1px solid #f0f0f0;
+    }
+    #debucsser__tagname strong
+    {
+      padding:0px 2px 2px 2px;
+      color:rgba(52,152,219 ,1);
+    }
     `;
     document.body.appendChild(style);
   }
 }
+
+
+// only for demo purpose
+const explain = document.querySelector('.explain');
+explain.querySelector('button').addEventListener('click', () => {
+  explain.style.transform = 'translateX(2000px)';
+  document.querySelector('.wrapper').style.filter = 'none';
+});

--- a/module/debucsser.js
+++ b/module/debucsser.js
@@ -191,9 +191,3 @@ export default class Debucsser {
 }
 
 
-// only for demo purpose
-const explain = document.querySelector('.explain');
-explain.querySelector('button').addEventListener('click', () => {
-  explain.style.transform = 'translateX(2000px)';
-  document.querySelector('.wrapper').style.filter = 'none';
-});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,4 +1,5 @@
 {
+  "name": "DebucsserDEMO",
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
@@ -956,7 +957,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -974,11 +976,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -991,15 +995,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1102,7 +1109,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1112,6 +1120,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1124,17 +1133,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1151,6 +1163,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1223,7 +1236,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1233,6 +1247,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1308,7 +1323,8 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -1338,6 +1354,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -1355,6 +1372,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -1393,11 +1411,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },


### PR DESCRIPTION
(_Kudos to the team for cool idea and its implementation. I loved the idea and made a few changes that i think would be useful_)

### Implemented features
      
- Changed the display to flex so that debucsser__label is flexible with the content inside
- Introduced few more properties to be displayed in the label when the element is inspected such as
   - display type
   - color
   - font-family
   - background
- Displaying the heading of the label with the tag name, class name,id combined like chrome inspector ex: h1.heading1#head1
- **Fixed a minor Issue**: When the ctrl+shift is pressed, then the outlines of the items in the label are also displayed. This is fixed

![UpdatedLabel](https://user-images.githubusercontent.com/20256099/55564094-ca822500-5714-11e9-93a1-6b7570c14e43.png)
